### PR TITLE
feat: constrain application width on wide displays

### DIFF
--- a/src/components/AddTransactionSheet.tsx
+++ b/src/components/AddTransactionSheet.tsx
@@ -672,17 +672,21 @@ const AddTransactionSheet = ({ categories, customColumns, transactions, projectC
   return (
     <>
       <Sheet open={open} onOpenChange={handleOpenChange}>
-        <SheetTrigger asChild>
-          <Button
-            ref={triggerRef}
-            size="icon"
-            className="fixed bottom-6 left-6 z-40 h-14 w-14 rounded-full gradient-primary shadow-lg shadow-primary/30"
-            aria-label={t("tx.addTransaction") || "Add transaction"}
-            data-testid="add-transaction-button"
-          >
-            <Plus className="h-6 w-6" />
-          </Button>
-        </SheetTrigger>
+        <div className="fixed bottom-0 left-0 right-0 z-40 pointer-events-none">
+          <div className="max-w-screen-2xl mx-auto px-4 relative h-24">
+            <SheetTrigger asChild>
+              <Button
+                ref={triggerRef}
+                size="icon"
+                className="absolute bottom-6 left-4 pointer-events-auto h-14 w-14 rounded-full gradient-primary shadow-lg shadow-primary/30"
+                aria-label={t("tx.addTransaction") || "Add transaction"}
+                data-testid="add-transaction-button"
+              >
+                <Plus className="h-6 w-6" />
+              </Button>
+            </SheetTrigger>
+          </div>
+        </div>
         <SheetContent
           ref={sheetRef}
           onKeyDown={handleFormKeyDown}

--- a/src/components/PWAInstructions.tsx
+++ b/src/components/PWAInstructions.tsx
@@ -69,34 +69,36 @@ export const PWAInstructions = () => {
   return (
     <>
       {show && (
-        <div className="fixed bottom-20 left-4 right-4 z-50 animate-in fade-in slide-in-from-bottom-4 duration-300">
-          <div className="glass-card p-4 flex flex-col gap-3 border-primary/20 bg-primary/5 shadow-lg">
-            <div className="flex items-start justify-between">
-              <div className="flex items-center gap-2">
-                <div className="p-2 rounded-lg bg-primary/10">
-                  <Download className="h-5 w-5 text-primary" />
+        <div className="fixed bottom-20 left-0 right-0 z-50 pointer-events-none">
+          <div className="max-w-screen-2xl mx-auto px-4 animate-in fade-in slide-in-from-bottom-4 duration-300">
+            <div className="glass-card p-4 flex flex-col gap-3 border-primary/20 bg-primary/5 shadow-lg pointer-events-auto">
+              <div className="flex items-start justify-between">
+                <div className="flex items-center gap-2">
+                  <div className="p-2 rounded-lg bg-primary/10">
+                    <Download className="h-5 w-5 text-primary" />
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-sm">{t("pwa.installTitle")}</h3>
+                    <p className="text-xs text-muted-foreground line-clamp-2">
+                      {t("pwa.installDesc")}
+                    </p>
+                  </div>
                 </div>
-                <div>
-                  <h3 className="font-semibold text-sm">{t("pwa.installTitle")}</h3>
-                  <p className="text-xs text-muted-foreground line-clamp-2">
-                    {t("pwa.installDesc")}
-                  </p>
-                </div>
+                <button 
+                  onClick={handleDismiss}
+                  className="p-1 hover:bg-muted rounded-full transition-colors"
+                >
+                  <X className="h-4 w-4 text-muted-foreground" />
+                </button>
               </div>
-              <button 
-                onClick={handleDismiss}
-                className="p-1 hover:bg-muted rounded-full transition-colors"
+              <Button 
+                size="sm" 
+                className="w-full gradient-primary text-xs font-semibold"
+                onClick={handleInstall}
               >
-                <X className="h-4 w-4 text-muted-foreground" />
-              </button>
+                {t("pwa.installBtn")}
+              </Button>
             </div>
-            <Button 
-              size="sm" 
-              className="w-full gradient-primary text-xs font-semibold"
-              onClick={handleInstall}
-            >
-              {t("pwa.installBtn")}
-            </Button>
           </div>
         </div>
       )}

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -176,16 +176,17 @@ const Auth = () => {
   };
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center px-6 gradient-dark" data-testid="auth-page">
-      {/* Language toggle */}
-      <button
-        onClick={() => setLocale(locale === "en" ? "ko" : "en")}
-        className="fixed top-4 right-4 z-50 rounded-lg bg-muted/50 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
-      >
-        {locale === "en" ? t("lang.ko") : t("lang.en")}
-      </button>
-
+    <div className="flex min-h-screen flex-col items-center justify-center px-6 gradient-dark relative" data-testid="auth-page">
       <div className="w-full max-w-sm animate-fade-in">
+        <div className="flex justify-end mb-4">
+          <button
+            onClick={() => setLocale(locale === "en" ? "ko" : "en")}
+            className="rounded-lg bg-muted/50 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {locale === "en" ? t("lang.ko") : t("lang.en")}
+          </button>
+        </div>
+
         <div className="mb-10 text-center">
           <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl gradient-primary">
             <ArrowRightLeft className="h-7 w-7 text-primary-foreground" />

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -380,7 +380,8 @@ const Dashboard = () => {
   return (
     <div className="min-h-screen bg-background pb-24" data-testid="dashboard" data-pending-mutations={pendingCount}>
       <header className="sticky top-0 z-40 bg-background/80 backdrop-blur-xl border-b border-border/30 px-4 py-2">
-        <div className="flex items-center justify-between relative">
+        <div className="max-w-screen-2xl mx-auto">
+          <div className="flex items-center justify-between relative">
           <div className="flex items-center gap-1">
             <ProjectSwitcher
               ref={projectSwitcherRef}
@@ -520,9 +521,10 @@ const Dashboard = () => {
             )}
           </div>
         )}
+        </div>
       </header>
 
-      <main className="px-4 pt-4">
+      <main className="px-4 pt-4 max-w-screen-2xl mx-auto">
         {!activeProject ? (
           <div className="flex flex-col items-center justify-center py-20 text-center animate-fade-in">
             <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-muted">


### PR DESCRIPTION
Constrain application content and UI elements to a maximum width of 1536px (screen-2xl) to improve readability on ultra-wide displays.

Changes:
- **Dashboard**: Added max-width constraints to header and main content.
- **Auth Page**: Moved language toggle inside the centered container to keep it near the login card.
- **UI Elements**: Constrained FAB (Add Transaction) and PWA banners to the content width.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined layout positioning of key UI elements for improved visual alignment across screen sizes
  * Enhanced responsive design with better-centered content on larger screens
  * Improved spacing and organization of action buttons and interface components throughout the app

<!-- end of auto-generated comment: release notes by coderabbit.ai -->