### PR TITLE
Fix entries per page selector text truncation

### DIFF
--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -537,7 +537,7 @@ const TransactionList = forwardRef<TransactionListHandle, Props>(({
                 value={String(pageSize)}
                 onValueChange={(v) => { const n = Number(v); setPageSize(n); localStorage.setItem("tx_page_size", v); setPage(0); }}
                 items={PAGE_SIZES.map((s) => ({ value: String(s), label: String(s) }))}
-                className="h-7 w-[72px] text-xs bg-muted/30 border-border/50 px-2"
+                className="h-7 min-w-[72px] w-fit text-xs bg-muted/30 border-border/50 px-2"
                 showNumbers
               />
               <span className="text-xs text-muted-foreground">/ {t("tx.page") || "page"}</span>


### PR DESCRIPTION
When the user increases the text size, the "entries per page" selector in the `TransactionList` component truncates the number because of a hardcoded fixed width (`w-[72px]`). This PR fixes it by using `min-w-[72px] w-fit` so it can expand horizontally as needed while retaining the minimum width for normal text sizes.

---
*PR created automatically by Jules for task [16751646232938626446](https://jules.google.com/task/16751646232938626446) started by @CJ-1981*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the page-size dropdown layout to dynamically adjust its width based on content while maintaining a minimum size, improving visual flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->