### PR TITLE
feat: Transaction list enhancements, permissions, and file upload fixes

### DIFF
--- a/src/components/AddTransactionSheet.tsx
+++ b/src/components/AddTransactionSheet.tsx
@@ -692,7 +692,7 @@ const AddTransactionSheet = ({ categories, customColumns, transactions, projectC
           ref={sheetRef}
           onKeyDown={handleFormKeyDown}
           side="bottom"
-          className="rounded-t-3xl bg-card border-border/50 px-0 pb-0 h-[85vh] sm:h-[90vh] flex flex-col outline-none shadow-2xl"
+          className="rounded-t-3xl bg-card border-border/50 px-0 pb-0 h-[85vh] sm:h-[90vh] flex flex-col outline-none shadow-2xl w-full max-w-2xl mx-auto left-1/2 -translate-x-1/2"
           data-testid="add-transaction-form"
           tabIndex={-1}
           onOpenAutoFocus={(e) => {

--- a/src/components/AddTransactionSheet.tsx
+++ b/src/components/AddTransactionSheet.tsx
@@ -692,7 +692,7 @@ const AddTransactionSheet = ({ categories, customColumns, transactions, projectC
           ref={sheetRef}
           onKeyDown={handleFormKeyDown}
           side="bottom"
-          className="rounded-t-3xl bg-card border-border/50 px-0 pb-0 h-[85vh] sm:h-[90vh] flex flex-col outline-none shadow-2xl w-full max-w-2xl mx-auto left-1/2 -translate-x-1/2"
+          className="rounded-t-3xl bg-card border-border/50 px-0 pb-0 h-[85vh] sm:h-[90vh] flex flex-col outline-none shadow-2xl w-full max-w-2xl mx-auto"
           data-testid="add-transaction-form"
           tabIndex={-1}
           onOpenAutoFocus={(e) => {

--- a/src/components/AddTransactionSheet.tsx
+++ b/src/components/AddTransactionSheet.tsx
@@ -512,6 +512,7 @@ const AddTransactionSheet = ({ categories, customColumns, transactions, projectC
 
             <div className="flex items-center gap-2">
               <FileUploadSheet
+                uploadMode="single"
                 onUpload={async (file, remark) => {
                   // Store file as pending until transaction is created
                   setPendingFiles(prev => [...prev, { file, remark }]);

--- a/src/components/BulkEditSheet.tsx
+++ b/src/components/BulkEditSheet.tsx
@@ -59,7 +59,7 @@ const BulkEditSheet = ({ transactions, categories, open, onOpenChange, onBulkUpd
 
   return (
     <Sheet open={open} onOpenChange={handleSheetOpenChange}>
-      <SheetContent side="bottom" className="rounded-t-3xl bg-card border-border/50 px-0 pb-0 max-h-[60vh] flex flex-col">
+      <SheetContent side="bottom" className="rounded-t-3xl bg-card border-border/50 px-0 pb-0 max-h-[60vh] flex flex-col w-full max-w-2xl mx-auto left-1/2 -translate-x-1/2">
         <div className="px-6 pt-6 pb-2 shrink-0 border-b border-border/5">
           <SheetHeader>
             <SheetTitle className="text-foreground">

--- a/src/components/BulkEditSheet.tsx
+++ b/src/components/BulkEditSheet.tsx
@@ -59,7 +59,7 @@ const BulkEditSheet = ({ transactions, categories, open, onOpenChange, onBulkUpd
 
   return (
     <Sheet open={open} onOpenChange={handleSheetOpenChange}>
-      <SheetContent side="bottom" className="rounded-t-3xl bg-card border-border/50 px-0 pb-0 max-h-[60vh] flex flex-col w-full max-w-2xl mx-auto left-1/2 -translate-x-1/2">
+      <SheetContent side="bottom" className="rounded-t-3xl bg-card border-border/50 px-0 pb-0 max-h-[60vh] flex flex-col w-full max-w-2xl mx-auto">
         <div className="px-6 pt-6 pb-2 shrink-0 border-b border-border/5">
           <SheetHeader>
             <SheetTitle className="text-foreground">

--- a/src/components/ExportTransactions.tsx
+++ b/src/components/ExportTransactions.tsx
@@ -64,6 +64,12 @@ const escapeXML = (val: unknown) => {
 const formatAmount = (tx: Transaction) =>
   `${tx.type === "income" ? "" : "-"}${Number(tx.amount).toFixed(2)}`;
 
+const translateType = (type: string, t: (k: string) => string) => {
+  if (type === "income") return t("tx.income") || "Income";
+  if (type === "expense") return t("tx.expense") || "Expense";
+  return type;
+};
+
 const formatDate = (tx: Transaction) =>
   format(parseISO(tx.transaction_date), "yyyy-MM-dd");
 
@@ -89,11 +95,12 @@ const getCustomVal = (tx: Transaction, col: CustomColumn) => {
   return col.column_type === "numeric" ? Number(val).toFixed(2) : String(val);
 };
 
-const exportCSV = (transactions: Transaction[], h: ColumnHeaders, cols: CustomColumn[], msg: string, categories?: Category[]) => {
+const exportCSV = (transactions: Transaction[], h: ColumnHeaders, cols: CustomColumn[], msg: string, categories?: Category[], t?: (k: string) => string) => {
   const colHeaders = cols.map((c) => c.name).join(",");
   const header = `${h.date},${h.type},${h.category},Code,${h.description},${h.amount},Currency${cols.length ? "," + colHeaders : ""}`;
   const rows = transactions.map((tx) => {
-    const base = `${formatDate(tx)},${tx.type},"${tx.category}","${getCategoryCode(tx, categories)}","${tx.description || ""}",${formatAmount(tx)},"${tx.currency || ""}"`;
+    const typeVal = t ? translateType(tx.type, t) : tx.type;
+    const base = `${formatDate(tx)},"${typeVal}","${tx.category}","${getCategoryCode(tx, categories)}","${tx.description || ""}",${formatAmount(tx)},"${tx.currency || ""}"`;
     const custom = cols.map((c) => `"${getCustomVal(tx, c)}"`).join(",");
     return cols.length ? `${base},${custom}` : base;
   });
@@ -101,7 +108,7 @@ const exportCSV = (transactions: Transaction[], h: ColumnHeaders, cols: CustomCo
   downloadFile([header, ...rows].join("\n"), `transactions_${timestamp}.csv`, "text/csv", msg);
 };
 
-const exportXLS = (transactions: Transaction[], h: ColumnHeaders, cols: CustomColumn[], msg: string, categories?: Category[]) => {
+const exportXLS = (transactions: Transaction[], h: ColumnHeaders, cols: CustomColumn[], msg: string, categories?: Category[], t?: (k: string) => string) => {
   const colNames = cols.map((c) => c.name);
   const header = `<Row ss:AutoFitHeight="0">
     <Cell><Data ss:Type="String">${escapeXML(h.date)}</Data></Cell>
@@ -115,6 +122,7 @@ const exportXLS = (transactions: Transaction[], h: ColumnHeaders, cols: CustomCo
   </Row>`;
 
   const rows = transactions.map((tx) => {
+    const typeVal = t ? translateType(tx.type, t) : tx.type;
     const customCells = cols.map((c) => {
       const val = getCustomVal(tx, c);
       const type = c.column_type === "numeric" ? "Number" : "String";
@@ -122,7 +130,7 @@ const exportXLS = (transactions: Transaction[], h: ColumnHeaders, cols: CustomCo
     }).join("");
     return `<Row ss:AutoFitHeight="0">
       <Cell><Data ss:Type="String">${formatDate(tx)}</Data></Cell>
-      <Cell><Data ss:Type="String">${tx.type}</Data></Cell>
+      <Cell><Data ss:Type="String">${escapeXML(typeVal)}</Data></Cell>
       <Cell><Data ss:Type="String">${escapeXML(tx.category)}</Data></Cell>
       <Cell><Data ss:Type="String">${escapeXML(getCategoryCode(tx, categories))}</Data></Cell>
       <Cell><Data ss:Type="String">${escapeXML(tx.description || "")}</Data></Cell>
@@ -135,7 +143,7 @@ const exportXLS = (transactions: Transaction[], h: ColumnHeaders, cols: CustomCo
   const totalRows = transactions.length + 1; // header + data rows
   const totalCols = 7 + cols.length; // 7 base columns + custom columns
 
-  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+  const xml = \`<?xml version="1.0" encoding="UTF-8"?>
 <?mso-application progid="Excel.Sheet"?>
 <Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
  xmlns:o="urn:schemas-microsoft-com:office:office"
@@ -143,7 +151,7 @@ const exportXLS = (transactions: Transaction[], h: ColumnHeaders, cols: CustomCo
  xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"
  xmlns:html="http://www.w3.org/TR/REC-html40">
  <DocumentProperties xmlns="urn:schemas-microsoft-com:office:office">
-  <Created>${new Date().toISOString()}</Created>
+  <Created>\${new Date().toISOString()}</Created>
   <Version>16.00</Version>
  </DocumentProperties>
  <ExcelWorkbook xmlns="urn:schemas-microsoft-com:office:excel">
@@ -155,27 +163,28 @@ const exportXLS = (transactions: Transaction[], h: ColumnHeaders, cols: CustomCo
   <ProtectWindows>False</ProtectWindows>
  </ExcelWorkbook>
  <Worksheet ss:Name="Transactions">
-  <Table ss:ExpandedColumnCount="${totalCols}" ss:ExpandedRowCount="${totalRows}" x:FullRows="1" ss:DefaultRowHeight="15">
-   ${header}
-   ${rows}
+  <Table ss:ExpandedColumnCount="\${totalCols}" ss:ExpandedRowCount="\${totalRows}" x:FullRows="1" ss:DefaultRowHeight="15">
+   \${header}
+   \${rows}
   </Table>
  </Worksheet>
-</Workbook>`;
+</Workbook>\`;
   const timestamp = getExportTimestamp();
-  downloadFile(xml, `transactions_${timestamp}.xls`, "application/vnd.ms-excel", msg);
+  downloadFile(xml, `transactions_\${timestamp}.xls`, "application/vnd.ms-excel", msg);
 };
 
-const exportMarkdown = (transactions: Transaction[], h: ColumnHeaders, cols: CustomColumn[], msg: string, categories?: Category[]) => {
-  const colH = cols.map((c) => ` ${c.name} |`).join("");
-  const header = `| ${h.date} | ${h.type} | ${h.category} | Code | ${h.description} | ${h.amount} | Currency |${colH}`;
+const exportMarkdown = (transactions: Transaction[], h: ColumnHeaders, cols: CustomColumn[], msg: string, categories?: Category[], t?: (k: string) => string) => {
+  const colH = cols.map((c) => ` \${c.name} |`).join("");
+  const header = \`| \${h.date} | \${h.type} | \${h.category} | Code | \${h.description} | \${h.amount} | Currency |\${colH}\`;
   const colSep = cols.map(() => " ---: |").join("");
-  const sep = `| --- | --- | --- | --- | --- | ---: | --- |${colSep}`;
+  const sep = \`| --- | --- | --- | --- | --- | ---: | --- |\${colSep}\`;
   const rows = transactions.map((tx) => {
-    const colVals = cols.map((c) => ` ${getCustomVal(tx, c) || "-"} |`).join("");
-    return `| ${formatDate(tx)} | ${tx.type} | ${tx.category} | ${getCategoryCode(tx, categories) || "-"} | ${tx.description || "-"} | ${formatAmount(tx)} | ${tx.currency || "-"} |${colVals}`;
+    const typeVal = t ? translateType(tx.type, t) : tx.type;
+    const colVals = cols.map((c) => ` \${getCustomVal(tx, c) || "-"} |`).join("");
+    return \`| \${formatDate(tx)} | \${typeVal} | \${tx.category} | \${getCategoryCode(tx, categories) || "-"} | \${tx.description || "-"} | \${formatAmount(tx)} | \${tx.currency || "-"} |\${colVals}\`;
   });
   const timestamp = getExportTimestamp();
-  downloadFile([header, sep, ...rows].join("\n"), `transactions_${timestamp}.md`, "text/markdown", msg);
+  downloadFile([header, sep, ...rows].join("\n"), `transactions_\${timestamp}.md`, "text/markdown", msg);
 };
 
 // --- CSV Import helpers ---
@@ -418,15 +427,15 @@ const ExportTransactions = ({ transactions, headers, customColumns, isViewer, ca
         <DropdownMenuContent align="end">
           {transactions.length > 0 && (
             <>
-              <DropdownMenuItem onClick={() => exportCSV(transactions, headers, visibleCols, msg, categories)}>
+              <DropdownMenuItem onClick={() => exportCSV(transactions, headers, visibleCols, msg, categories, t)}>
                 <FileSpreadsheet className="h-4 w-4 mr-2" />
                 {t("export.csv")}
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => exportXLS(transactions, headers, visibleCols, msg, categories)}>
+              <DropdownMenuItem onClick={() => exportXLS(transactions, headers, visibleCols, msg, categories, t)}>
                 <FileSpreadsheet className="h-4 w-4 mr-2" />
                 {t("export.xls")}
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => exportMarkdown(transactions, headers, visibleCols, msg, categories)}>
+              <DropdownMenuItem onClick={() => exportMarkdown(transactions, headers, visibleCols, msg, categories, t)}>
                 <FileText className="h-4 w-4 mr-2" />
                 {t("export.markdown")}
               </DropdownMenuItem>

--- a/src/components/ExportTransactions.tsx
+++ b/src/components/ExportTransactions.tsx
@@ -152,7 +152,7 @@ const exportXLS = (transactions: Transaction[], h: ColumnHeaders, cols: CustomCo
  xmlns:html="http://www.w3.org/TR/REC-html40">
  <DocumentProperties xmlns="urn:schemas-microsoft-com:office:office">
   <Created>${new Date().toISOString()}</Created>
-  <Version(16.00)</Version>
+  <Version>16.00</Version>
  </DocumentProperties>
  <ExcelWorkbook xmlns="urn:schemas-microsoft-com:office:excel">
   <WindowHeight>9000</WindowHeight>

--- a/src/components/ExportTransactions.tsx
+++ b/src/components/ExportTransactions.tsx
@@ -241,6 +241,17 @@ interface ValidationResult { row: ImportRow; errors: string[]; valid: boolean; p
 function validateRow(row: ImportRow, categories: Category[], projectCurrency: string, t: (k: string) => string, customColumns: CustomColumn[]): ValidationResult {
   const errors: string[] = [];
   let typeLower = row.type.toLowerCase();
+  
+  // Normalize localized types back to canonical "income"/"expense"
+  const incomeLabel = (t("tx.income") || "Income").toLowerCase();
+  const expenseLabel = (t("tx.expense") || "Expense").toLowerCase();
+  
+  if (typeLower === incomeLabel) {
+    typeLower = "income";
+  } else if (typeLower === expenseLabel) {
+    typeLower = "expense";
+  }
+
   let amount = Number(row.amount);
 
   // If amount is negative, treat it as an expense and use absolute value

--- a/src/components/ExportTransactions.tsx
+++ b/src/components/ExportTransactions.tsx
@@ -143,7 +143,7 @@ const exportXLS = (transactions: Transaction[], h: ColumnHeaders, cols: CustomCo
   const totalRows = transactions.length + 1; // header + data rows
   const totalCols = 7 + cols.length; // 7 base columns + custom columns
 
-  const xml = \`<?xml version="1.0" encoding="UTF-8"?>
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <?mso-application progid="Excel.Sheet"?>
 <Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
  xmlns:o="urn:schemas-microsoft-com:office:office"
@@ -151,8 +151,8 @@ const exportXLS = (transactions: Transaction[], h: ColumnHeaders, cols: CustomCo
  xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"
  xmlns:html="http://www.w3.org/TR/REC-html40">
  <DocumentProperties xmlns="urn:schemas-microsoft-com:office:office">
-  <Created>\${new Date().toISOString()}</Created>
-  <Version>16.00</Version>
+  <Created>${new Date().toISOString()}</Created>
+  <Version(16.00)</Version>
  </DocumentProperties>
  <ExcelWorkbook xmlns="urn:schemas-microsoft-com:office:excel">
   <WindowHeight>9000</WindowHeight>
@@ -163,28 +163,28 @@ const exportXLS = (transactions: Transaction[], h: ColumnHeaders, cols: CustomCo
   <ProtectWindows>False</ProtectWindows>
  </ExcelWorkbook>
  <Worksheet ss:Name="Transactions">
-  <Table ss:ExpandedColumnCount="\${totalCols}" ss:ExpandedRowCount="\${totalRows}" x:FullRows="1" ss:DefaultRowHeight="15">
-   \${header}
-   \${rows}
+  <Table ss:ExpandedColumnCount="${totalCols}" ss:ExpandedRowCount="${totalRows}" x:FullRows="1" ss:DefaultRowHeight="15">
+   ${header}
+   ${rows}
   </Table>
  </Worksheet>
-</Workbook>\`;
+</Workbook>`;
   const timestamp = getExportTimestamp();
-  downloadFile(xml, `transactions_\${timestamp}.xls`, "application/vnd.ms-excel", msg);
+  downloadFile(xml, `transactions_${timestamp}.xls`, "application/vnd.ms-excel", msg);
 };
 
 const exportMarkdown = (transactions: Transaction[], h: ColumnHeaders, cols: CustomColumn[], msg: string, categories?: Category[], t?: (k: string) => string) => {
-  const colH = cols.map((c) => ` \${c.name} |`).join("");
-  const header = \`| \${h.date} | \${h.type} | \${h.category} | Code | \${h.description} | \${h.amount} | Currency |\${colH}\`;
+  const colH = cols.map((c) => ` ${c.name} |`).join("");
+  const header = `| ${h.date} | ${h.type} | ${h.category} | Code | ${h.description} | ${h.amount} | Currency |${colH}`;
   const colSep = cols.map(() => " ---: |").join("");
-  const sep = \`| --- | --- | --- | --- | --- | ---: | --- |\${colSep}\`;
+  const sep = `| --- | --- | --- | --- | --- | ---: | --- |${colSep}`;
   const rows = transactions.map((tx) => {
     const typeVal = t ? translateType(tx.type, t) : tx.type;
-    const colVals = cols.map((c) => ` \${getCustomVal(tx, c) || "-"} |`).join("");
-    return \`| \${formatDate(tx)} | \${typeVal} | \${tx.category} | \${getCategoryCode(tx, categories) || "-"} | \${tx.description || "-"} | \${formatAmount(tx)} | \${tx.currency || "-"} |\${colVals}\`;
+    const colVals = cols.map((c) => ` ${getCustomVal(tx, c) || "-"} |`).join("");
+    return `| ${formatDate(tx)} | ${typeVal} | ${tx.category} | ${getCategoryCode(tx, categories) || "-"} | ${tx.description || "-"} | ${formatAmount(tx)} | ${tx.currency || "-"} |${colVals}`;
   });
   const timestamp = getExportTimestamp();
-  downloadFile([header, sep, ...rows].join("\n"), `transactions_\${timestamp}.md`, "text/markdown", msg);
+  downloadFile([header, sep, ...rows].join("\n"), `transactions_${timestamp}.md`, "text/markdown", msg);
 };
 
 // --- CSV Import helpers ---

--- a/src/components/TransactionDetailSheet.tsx
+++ b/src/components/TransactionDetailSheet.tsx
@@ -15,6 +15,7 @@ import { cn } from "@/lib/utils";
 import { Transaction } from "@/hooks/useTransactions";
 import { Category } from "@/hooks/useCategories";
 import { CustomColumn } from "@/hooks/useCustomColumns";
+import { UserRole } from "@/hooks/useUserRole";
 import { useI18n } from "@/hooks/useI18n";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { toast } from "sonner";
@@ -40,6 +41,8 @@ interface Props {
   onUpdate: (id: string, updates: Partial<Pick<Transaction, "type" | "amount" | "category" | "description" | "transaction_date" | "custom_values" | "currency">>) => Promise<void>;
   onDelete: (id: string) => Promise<void>;
   isViewer?: boolean;
+  role?: UserRole;
+  isOwner?: boolean;
   /** For multi-edit: full list of selected transactions */
   transactionList?: Transaction[];
   onNavigate?: (tx: Transaction) => void;
@@ -53,7 +56,24 @@ interface Props {
   projectCurrency?: string;
 }
 
-const TransactionDetailSheet = ({ transaction, categories, customColumns, open, onOpenChange, onUpdate, onDelete, isViewer, transactionList, onNavigate, allTransactions, projectId, onViewInFiles, projectCurrency }: Props) => {
+const TransactionDetailSheet = ({ 
+  transaction, 
+  categories, 
+  customColumns, 
+  open, 
+  onOpenChange, 
+  onUpdate, 
+  onDelete, 
+  isViewer, 
+  role,
+  isOwner,
+  transactionList, 
+  onNavigate, 
+  allTransactions, 
+  projectId, 
+  onViewInFiles, 
+  projectCurrency 
+}: Props) => {
   const { user } = useAuth();
   const [type, setType] = useState<"income" | "expense">("expense");
   const [amount, setAmount] = useState("");
@@ -75,7 +95,8 @@ const TransactionDetailSheet = ({ transaction, categories, customColumns, open, 
   const { files, isLoading: isLoadingFiles, downloadFile, uploadFile, isUploading } = useFiles(projectId || "");
   const transactionFiles = transaction && projectId ? files.filter(f => f.transaction_id === transaction.id) : [];
 
-  const isOwn = !isViewer && transaction?.user_id === user?.id;
+  const isAdmin = role === "admin" || isOwner;
+  const isOwn = !isViewer && (isAdmin || transaction?.user_id === user?.id);
 
   // Build suggestion lists per text column
   const columnSuggestions = useMemo(() => {

--- a/src/components/TransactionDetailSheet.tsx
+++ b/src/components/TransactionDetailSheet.tsx
@@ -709,7 +709,7 @@ const TransactionDetailSheet = ({
           ref={sheetRef}
           onKeyDown={handleFormKeyDown}
           side="bottom"
-          className="rounded-t-3xl bg-card border-border/50 px-0 pb-0 h-[85vh] sm:h-[90vh] flex flex-col outline-none shadow-2xl"
+          className="rounded-t-3xl bg-card border-border/50 px-0 pb-0 h-[85vh] sm:h-[90vh] flex flex-col outline-none shadow-2xl w-full max-w-2xl mx-auto left-1/2 -translate-x-1/2"
           tabIndex={-1}
           onOpenAutoFocus={(e) => {
             if (!isMobile && amountInputRef.current && !amountInputRef.current.disabled) {

--- a/src/components/TransactionDetailSheet.tsx
+++ b/src/components/TransactionDetailSheet.tsx
@@ -709,7 +709,7 @@ const TransactionDetailSheet = ({
           ref={sheetRef}
           onKeyDown={handleFormKeyDown}
           side="bottom"
-          className="rounded-t-3xl bg-card border-border/50 px-0 pb-0 h-[85vh] sm:h-[90vh] flex flex-col outline-none shadow-2xl w-full max-w-2xl mx-auto left-1/2 -translate-x-1/2"
+          className="rounded-t-3xl bg-card border-border/50 px-0 pb-0 h-[85vh] sm:h-[90vh] flex flex-col outline-none shadow-2xl w-full max-w-2xl mx-auto"
           tabIndex={-1}
           onOpenAutoFocus={(e) => {
             if (!isMobile && amountInputRef.current && !amountInputRef.current.disabled) {

--- a/src/components/TransactionDetailSheet.tsx
+++ b/src/components/TransactionDetailSheet.tsx
@@ -409,6 +409,7 @@ const TransactionDetailSheet = ({
           {isOwn && transaction && (
             <div className="flex items-center gap-2">
               <FileUploadSheet
+                uploadMode="single"
                 onUpload={async (file, remark) => {
                   try {
                     await uploadFile({ file, remark, transactionId: transaction.id });

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -8,6 +8,7 @@ import { CustomColumn } from "@/hooks/useCustomColumns";
 import { useI18n } from "@/hooks/useI18n";
 import { useAuth } from "@/hooks/useAuth";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { UserRole } from "@/hooks/useUserRole";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import NumberedSelect from "@/components/NumberedSelect";
@@ -35,6 +36,8 @@ interface Props {
   headers: ColumnHeaders;
   customColumns: CustomColumn[];
   isViewer?: boolean;
+  role?: UserRole;
+  isOwner?: boolean;
   hasNextPage?: boolean;
   fetchNextPage?: () => void;
   isFetchingNextPage?: boolean;
@@ -67,6 +70,8 @@ const TransactionList = forwardRef<TransactionListHandle, Props>(({
   headers, 
   customColumns, 
   isViewer,
+  role,
+  isOwner,
   hasNextPage,
   fetchNextPage,
   isFetchingNextPage
@@ -74,6 +79,7 @@ const TransactionList = forwardRef<TransactionListHandle, Props>(({
   const { t } = useI18n();
   const { user } = useAuth();
   const isMobile = useIsMobile();
+  const isAdmin = role === "admin" || isOwner;
   const searchRef = useRef<HTMLInputElement>(null);
   useImperativeHandle(ref, () => ({ focusSearch: () => searchRef.current?.focus() }));
   const [searchQuery, setSearchQuery] = useState("");
@@ -111,7 +117,8 @@ const TransactionList = forwardRef<TransactionListHandle, Props>(({
 
   // Handle long press on transaction item
   const handleTouchStart = (tx: Transaction, e: React.TouchEvent) => {
-    if (!isMobile || isViewer || !ownTxIds.has(tx.id) || isTouchBlocked()) return;
+    if (!isMobile || isViewer || isTouchBlocked()) return;
+    if (!isAdmin && tx.user_id !== user?.id) return;
 
     const touch = e.touches[0];
     const rect = e.currentTarget.getBoundingClientRect();
@@ -296,7 +303,10 @@ const TransactionList = forwardRef<TransactionListHandle, Props>(({
     return sums;
   }, [selectMode, selected, filteredTransactions]);
 
-  const ownTxIds = new Set(transactions.filter((tx) => tx.user_id === user?.id).map((tx) => tx.id));
+  const ownTxIds = useMemo(() => 
+    new Set(transactions.filter((tx) => isAdmin || tx.user_id === user?.id).map((tx) => tx.id)),
+    [transactions, isAdmin, user?.id]
+  );
 
   const toggleSelect = (id: string) => {
     if (!ownTxIds.has(id)) return;
@@ -446,7 +456,7 @@ const TransactionList = forwardRef<TransactionListHandle, Props>(({
             selectMode ? toggleSelect(tx.id) : onSelect(tx);
           }}
           onContextMenu={(e) => {
-            if (!isViewer && !selectMode && ownTxIds.has(tx.id)) {
+            if (!isViewer && !selectMode && (isAdmin || tx.user_id === user?.id)) {
               e.preventDefault();
               setSelectMode(true);
               setSelected(new Set([tx.id]));

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -537,7 +537,7 @@ const TransactionList = forwardRef<TransactionListHandle, Props>(({
                 value={String(pageSize)}
                 onValueChange={(v) => { const n = Number(v); setPageSize(n); localStorage.setItem("tx_page_size", v); setPage(0); }}
                 items={PAGE_SIZES.map((s) => ({ value: String(s), label: String(s) }))}
-                className="h-7 w-[72px] text-xs bg-muted/30 border-border/50 px-2"
+                className="h-7 w-[4.5rem] text-xs bg-muted/30 border-border/50 px-2"
                 showNumbers
               />
               <span className="text-xs text-muted-foreground">/ {t("tx.page") || "page"}</span>

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -233,7 +233,7 @@ const TransactionList = forwardRef<TransactionListHandle, Props>(({
     const expenseTerm = (t("tx.expense") || "expense").toLowerCase();
 
     return transactions.filter((tx) => {
-      // Check for type match with translated terms
+      // @MX:NOTE Check for type match with translated terms
       if (tx.type === "income" && incomeTerm.includes(q)) return true;
       if (tx.type === "expense" && expenseTerm.includes(q)) return true;
 

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -227,7 +227,16 @@ const TransactionList = forwardRef<TransactionListHandle, Props>(({
   const filteredTransactions = useMemo(() => {
     if (!searchQuery.trim()) return transactions;
     const q = searchQuery.toLowerCase();
+    
+    // Translation keywords for type search
+    const incomeTerm = (t("tx.income") || "income").toLowerCase();
+    const expenseTerm = (t("tx.expense") || "expense").toLowerCase();
+
     return transactions.filter((tx) => {
+      // Check for type match with translated terms
+      if (tx.type === "income" && incomeTerm.includes(q)) return true;
+      if (tx.type === "expense" && expenseTerm.includes(q)) return true;
+
       if (tx.description?.toLowerCase().includes(q)) return true;
       if (tx.category.toLowerCase().includes(q)) return true;
       if (tx.type.toLowerCase().includes(q)) return true;
@@ -244,7 +253,7 @@ const TransactionList = forwardRef<TransactionListHandle, Props>(({
       }
       return false;
     });
-  }, [transactions, searchQuery, maskedColumnNames, categoryCodeMap]);
+  }, [transactions, searchQuery, maskedColumnNames, categoryCodeMap, t]);
 
   // Reset page when search or data changes
   const totalPages = Math.max(1, Math.ceil(filteredTransactions.length / pageSize));

--- a/src/components/files/FilePreviewDialog.tsx
+++ b/src/components/files/FilePreviewDialog.tsx
@@ -3,7 +3,7 @@
 // Created: 2026-03-21
 // Updated: 2026-03-22 - Added drag-to-close functionality for mobile
 
-import { File, Download, Loader2 } from 'lucide-react';
+import { File, Download, Loader2, ZoomIn, ZoomOut, Maximize } from 'lucide-react';
 import { useState, useEffect, useRef, TouchEvent } from 'react';
 import { Button } from '@/components/ui/button';
 import {
@@ -56,6 +56,7 @@ const canPreview = (mimeType: string): boolean => {
 export const FilePreviewDialog = ({ file, open, onOpenChange }: FilePreviewDialogProps) => {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [zoom, setZoom] = useState(1);
   const isMobile = useIsMobile();
 
   // Drag-to-close state for mobile
@@ -66,6 +67,11 @@ export const FilePreviewDialog = ({ file, open, onOpenChange }: FilePreviewDialo
 
   // Threshold for closing dialog (in pixels)
   const CLOSE_THRESHOLD = 100;
+
+  // Reset zoom when file changes or dialog opens/closes
+  useEffect(() => {
+    setZoom(1);
+  }, [file, open]);
 
   // Fetch signed URL or create local URL when file or open state changes
   useEffect(() => {
@@ -139,9 +145,13 @@ export const FilePreviewDialog = ({ file, open, onOpenChange }: FilePreviewDialo
     }
   };
 
+  const handleZoomIn = () => setZoom(prev => Math.min(prev + 0.25, 5));
+  const handleZoomOut = () => setZoom(prev => Math.max(prev - 0.25, 0.25));
+  const handleResetZoom = () => setZoom(1);
+
   // Touch handlers for drag-to-close on mobile
   const handleTouchStart = (e: TouchEvent) => {
-    if (!isMobile) return;
+    if (!isMobile || zoom !== 1) return;
     const touch = e.touches[0];
     setDragStartY(touch.clientY);
     setCurrentDragY(touch.clientY);
@@ -149,7 +159,7 @@ export const FilePreviewDialog = ({ file, open, onOpenChange }: FilePreviewDialo
   };
 
   const handleTouchMove = (e: TouchEvent) => {
-    if (!isMobile || !isDragging) return;
+    if (!isMobile || !isDragging || zoom !== 1) return;
     const touch = e.touches[0];
     const deltaY = touch.clientY - dragStartY;
     // Only allow dragging down
@@ -159,7 +169,7 @@ export const FilePreviewDialog = ({ file, open, onOpenChange }: FilePreviewDialo
   };
 
   const handleTouchEnd = () => {
-    if (!isMobile || !isDragging) return;
+    if (!isMobile || !isDragging || zoom !== 1) return;
     const dragDistance = currentDragY - dragStartY;
 
     if (dragDistance > CLOSE_THRESHOLD) {
@@ -208,21 +218,43 @@ export const FilePreviewDialog = ({ file, open, onOpenChange }: FilePreviewDialo
         {/* Wrapper div for drag animation - doesn't interfere with DialogContent positioning */}
         <div ref={contentRef} style={dragWrapperStyle} className="flex flex-col flex-1 min-h-0 gap-4">
           <DialogHeader className="flex-shrink-0">
-            <DialogTitle className="truncate pr-8" title={file.file_name}>
-              {file.file_name}
-            </DialogTitle>
-            <DialogDescription className="sr-only">
-              File preview window for {file.file_name} showing file content or download options.
-            </DialogDescription>
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex-1 min-w-0">
+                <DialogTitle className="truncate pr-8" title={file.file_name}>
+                  {file.file_name}
+                </DialogTitle>
+                <DialogDescription className="sr-only">
+                  File preview window for {file.file_name} showing file content or download options.
+                </DialogDescription>
+              </div>
+              
+              {isImage && previewUrl && (
+                <div className="flex items-center gap-1 bg-muted/50 rounded-lg p-1">
+                  <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleZoomOut} disabled={zoom <= 0.25}>
+                    <ZoomOut className="h-4 w-4" />
+                  </Button>
+                  <span className="text-[10px] font-medium w-9 text-center">
+                    {Math.round(zoom * 100)}%
+                  </span>
+                  <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleZoomIn} disabled={zoom >= 5}>
+                    <ZoomIn className="h-4 w-4" />
+                  </Button>
+                  <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleResetZoom}>
+                    <Maximize className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
+            </div>
+
             {/* Visual indicator for drag-to-close on mobile */}
-            {isMobile && (
+            {isMobile && zoom === 1 && (
               <div className="flex justify-center pb-2">
                 <div className="w-12 h-1.5 bg-muted-foreground/30 rounded-full" />
               </div>
             )}
           </DialogHeader>
 
-          <div className="flex-1 min-h-0 flex items-center justify-center bg-muted/30 rounded-lg overflow-hidden">
+          <div className="flex-1 min-h-0 flex items-center justify-center bg-muted/30 rounded-lg overflow-auto">
             {isLoading ? (
               <div className="text-center">
                 <Loader2 className="h-8 w-8 text-muted-foreground mx-auto mb-4 animate-spin" />
@@ -235,11 +267,19 @@ export const FilePreviewDialog = ({ file, open, onOpenChange }: FilePreviewDialo
                 <p className="text-sm text-muted-foreground mt-2">Please download to view the file</p>
               </div>
             ) : isImage ? (
-              <img
-                src={previewUrl ?? ''}
-                alt={file.file_name}
-                className="max-w-full max-h-full object-contain"
-              />
+              <div 
+                className="relative transition-transform duration-200 ease-out flex items-center justify-center min-h-full min-w-full"
+                style={{ 
+                  transform: `scale(${zoom})`,
+                  transformOrigin: 'center center'
+                }}
+              >
+                <img
+                  src={previewUrl ?? ''}
+                  alt={file.file_name}
+                  className="max-w-full max-h-full object-contain shadow-md"
+                />
+              </div>
             ) : isPdf ? (
               <iframe
                 src={previewUrl ?? ''}

--- a/src/components/files/FilePreviewDialog.tsx
+++ b/src/components/files/FilePreviewDialog.tsx
@@ -68,7 +68,7 @@ export const FilePreviewDialog = ({ file, open, onOpenChange }: FilePreviewDialo
   // Threshold for closing dialog (in pixels)
   const CLOSE_THRESHOLD = 100;
 
-  // Reset zoom when file changes or dialog opens/closes
+  // @MX:NOTE Reset zoom when file changes or dialog opens/closes
   useEffect(() => {
     setZoom(1);
   }, [file, open]);
@@ -230,16 +230,16 @@ export const FilePreviewDialog = ({ file, open, onOpenChange }: FilePreviewDialo
               
               {isImage && previewUrl && (
                 <div className="flex items-center gap-1 bg-muted/50 rounded-lg p-1">
-                  <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleZoomOut} disabled={zoom <= 0.25}>
+                  <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleZoomOut} disabled={zoom <= 0.25} aria-label="Zoom out">
                     <ZoomOut className="h-4 w-4" />
                   </Button>
                   <span className="text-[10px] font-medium w-9 text-center">
                     {Math.round(zoom * 100)}%
                   </span>
-                  <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleZoomIn} disabled={zoom >= 5}>
+                  <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleZoomIn} disabled={zoom >= 5} aria-label="Zoom in">
                     <ZoomIn className="h-4 w-4" />
                   </Button>
-                  <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleResetZoom}>
+                  <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleResetZoom} aria-label="Reset zoom">
                     <Maximize className="h-4 w-4" />
                   </Button>
                 </div>

--- a/src/components/files/FileUploadSheet.tsx
+++ b/src/components/files/FileUploadSheet.tsx
@@ -257,7 +257,7 @@ export const FileUploadSheet = ({ onUpload, isUploading, remark = '', onRemarkCh
           {t('files.uploadFile')}
         </Button>
       </SheetTrigger>
-      <SheetContent side="bottom" className="rounded-t-3xl bg-card border-border/50 px-6 pb-8">
+      <SheetContent side="bottom" className="rounded-t-3xl bg-card border-border/50 px-6 pb-8 w-full max-w-2xl mx-auto left-1/2 -translate-x-1/2">
         <SheetHeader>
           <SheetTitle>{t('files.uploadFile')}</SheetTitle>
           <SheetDescription className="sr-only">

--- a/src/components/files/FileUploadSheet.tsx
+++ b/src/components/files/FileUploadSheet.tsx
@@ -257,7 +257,7 @@ export const FileUploadSheet = ({ onUpload, isUploading, remark = '', onRemarkCh
           {t('files.uploadFile')}
         </Button>
       </SheetTrigger>
-      <SheetContent side="bottom" className="rounded-t-3xl bg-card border-border/50 px-6 pb-8 w-full max-w-2xl mx-auto left-1/2 -translate-x-1/2">
+      <SheetContent side="bottom" className="rounded-t-3xl bg-card border-border/50 px-6 pb-8 w-full max-w-2xl mx-auto">
         <SheetHeader>
           <SheetTitle>{t('files.uploadFile')}</SheetTitle>
           <SheetDescription className="sr-only">

--- a/src/hooks/useFiles.tsx
+++ b/src/hooks/useFiles.tsx
@@ -33,7 +33,7 @@ const COMPRESSIBLE_IMAGE_TYPES = [
 ];
 
 // Compression quality (0.1 to 1.0, where 1.0 is maximum quality)
-const COMPRESSION_QUALITY = 0.8;
+const COMPRESSION_QUALITY = 0.5;
 
 // Maximum size before attempting compression (1MB)
 const COMPRESSION_THRESHOLD = IMAGE_COMPRESSION_THRESHOLD;

--- a/src/hooks/useTransactions.tsx
+++ b/src/hooks/useTransactions.tsx
@@ -2,6 +2,7 @@ import { useMemo, useCallback } from "react";
 import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/hooks/useAuth";
+import { useI18n } from "@/hooks/useI18n";
 import { toast } from "sonner";
 import { isNetworkError } from "@/lib/networkUtils";
 import { format } from "date-fns";
@@ -43,6 +44,7 @@ export type PageParam = { lastId: string } | { date: string; createdAt: string }
 
 export const useTransactions = (projectId: string | undefined) => {
   const { user, isStandalone } = useAuth();
+  const { t } = useI18n();
   const queryClient = useQueryClient();
 
   const TRANSACTIONS_KEY = ["infinite_transactions", projectId];
@@ -189,7 +191,7 @@ export const useTransactions = (projectId: string | undefined) => {
       return { previous };
     },
     onSuccess: (data, variables) => {
-      toast.success("Transaction added!", { duration: 2000 });
+      toast.success(t("tx.added"), { duration: 2000 });
       queryClient.setQueryData(TRANSACTIONS_KEY, (old: any) => {
         if (!old) return old;
         return {
@@ -202,11 +204,11 @@ export const useTransactions = (projectId: string | undefined) => {
     },
     onError: (err: any, variables, context) => {
       if (isNetworkError(err)) {
-        toast.info("Saved offline - will sync when online");
+        toast.info(t("dash.offlineHint"));
         return;
       }
       queryClient.setQueryData(TRANSACTIONS_KEY, context?.previous);
-      toast.error("Failed to add transaction");
+      toast.error(t("tx.addFailed"));
     },
     onSettled: () => {
       if (navigator.onLine || isStandalone) {
@@ -250,14 +252,14 @@ export const useTransactions = (projectId: string | undefined) => {
     },
     onError: (err: any, variables, context) => {
       if (isNetworkError(err)) {
-        toast.info("Update saved offline");
+        toast.info(t("dash.offlineHint"));
         return;
       }
       queryClient.setQueryData(TRANSACTIONS_KEY, context?.previous);
-      toast.error("Failed to update transaction");
+      toast.error(t("tx.updateFailed"));
     },
     onSuccess: (data, variables) => {
-      toast.success("Transaction updated!");
+      toast.success(t("tx.updated"));
       queryClient.setQueryData(TRANSACTIONS_KEY, (old: any) => {
         if (!old) return old;
         return {
@@ -317,14 +319,14 @@ export const useTransactions = (projectId: string | undefined) => {
     },
     onError: (err: any, variables, context) => {
       if (isNetworkError(err)) {
-        toast.info("Delete pending offline");
+        toast.info(t("dash.offlineHint"));
         return;
       }
       queryClient.setQueryData(TRANSACTIONS_KEY, context?.previous);
-      toast.error("Failed to delete transaction");
+      toast.error(t("tx.deleteFailed"));
     },
     onSuccess: () => {
-      toast.success("Transaction deleted");
+      toast.success(t("tx.deleted"));
       if (projectId && navigator.onLine) {
         queryClient.invalidateQueries({ queryKey: ["project-files", projectId] });
       }
@@ -373,12 +375,12 @@ export const useTransactions = (projectId: string | undefined) => {
       const { error } = await supabase.from("transactions").insert(rows);
       if (error) throw error;
     },
-    onSuccess: () => {
-      toast.success("Transactions imported!");
+    onSuccess: (data, variables) => {
+      toast.success(t("import.success").replace("{n}", String(variables.txs.length)));
     },
     onError: (err: any) => {
       if (isNetworkError(err)) return;
-      toast.error("Failed to import transactions");
+      toast.error(t("import.failed").replace("{n}", ""));
     },
     onSettled: () => {
       if (navigator.onLine || isStandalone) {

--- a/src/hooks/useTransactions.tsx
+++ b/src/hooks/useTransactions.tsx
@@ -378,9 +378,9 @@ export const useTransactions = (projectId: string | undefined) => {
     onSuccess: (data, variables) => {
       toast.success(t("import.success").replace("{n}", String(variables.txs.length)));
     },
-    onError: (err: any) => {
+    onError: (err: any, variables) => {
       if (isNetworkError(err)) return;
-      toast.error(t("import.failed").replace("{n}", ""));
+      toast.error(t("import.failed").replace("{n}", String(variables.txs.length)));
     },
     onSettled: () => {
       if (navigator.onLine || isStandalone) {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -440,6 +440,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "admin.archiveExportDelete": "Export & Archive",
     "admin.archiveConfirm": "This will export {n} transactions as CSV and soft-delete them. Continue?",
     "admin.archiveSuccess": "{n} transactions archived",
+    "admin.archiveError": "Failed to archive transactions",
     "admin.archiveEmpty": "No transactions found in selected range.",
     "admin.archiving": "Archiving...",
 
@@ -1105,6 +1106,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "admin.archiveExportDelete": "내보내기 & 아카이브",
     "admin.archiveConfirm": "{n}개의 거래를 CSV로 내보내고 삭제합니다. 계속하시겠습니까?",
     "admin.archiveSuccess": "{n}개의 거래가 아카이브되었습니다",
+    "admin.archiveError": "아카이브 처리에 실패했습니다",
     "admin.archiveEmpty": "선택한 기간에 거래가 없습니다.",
     "admin.archiving": "아카이브 중...",
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1082,7 +1082,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "admin.selectAll": "모두",
     "admin.selected": "{n}개 선택됨",
     "admin.transaction": "거래",
-    "admin.transactions": "거래",
+    "admin.transactions": "거래 내역",
     "admin.bulkRestore": "복원",
     "admin.bulkRestoreConfirmTitle": "선택한 거래를 복원하시겠습니까?",
     "admin.bulkDelete": "삭제",

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -330,10 +330,18 @@ const handleTransferOwnership = async (newOwnerId: string) => {
     const cols = customColumns;
     const colHeaders = cols.map((c) => c.name).join(",");
     const csvHeader = `${h.date},${h.type},${h.category},${h.description},${h.amount}${cols.length ? "," + colHeaders : ""}`;
+    
+    const translateType = (type: string) => {
+      if (type === "income") return t("tx.income") || "Income";
+      if (type === "expense") return t("tx.expense") || "Expense";
+      return type;
+    };
+
     const csvRows = txs.map((tx: { transaction_date: string; type: string; amount: number; category: string; description?: string; custom_values?: Record<string, number | string> }) => {
       const fmtDate = tx.transaction_date;
       const fmtAmt = `${tx.type === "income" ? "" : "-"}${Number(tx.amount).toFixed(2)}`;
-      const base = `${fmtDate},${tx.type},"${tx.category}","${tx.description || ""}",${fmtAmt}`;
+      const typeVal = translateType(tx.type);
+      const base = `${fmtDate},"${typeVal}","${tx.category}","${tx.description || ""}",${fmtAmt}`;
       const custom = cols.map((c) => {
         const val = tx.custom_values?.[c.name];
         return `"${val != null ? (c.column_type === "numeric" ? Number(val).toFixed(2) : String(val)) : ""}"`;

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -351,43 +351,52 @@ const handleTransferOwnership = async (newOwnerId: string) => {
     const csvContent = [csvHeader, ...csvRows].join("\n");
     const blob = new Blob([csvContent], { type: "text/csv" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `archive_${archiveFrom}_${archiveTo}.csv`;
-    a.click();
-    URL.revokeObjectURL(url);
 
-    // Soft-delete all archived transactions
-    const ids = txs.map((tx: { id: string }) => tx.id);
-    const batchSize = 50;
-    for (let i = 0; i < ids.length; i += batchSize) {
-      const batch = ids.slice(i, i + batchSize);
-      await supabase
-        .from("transactions")
-        .update({ deleted_at: new Date().toISOString() })
-        .in("id", batch);
-    }
-
-    // Unlink all files associated with archived transactions
-    for (let i = 0; i < ids.length; i += batchSize) {
-      const batch = ids.slice(i, i + batchSize);
-      const { error: unlinkError } = await supabase
-        .from("project_files")
-        .update({ transaction_id: null })
-        .in("transaction_id", batch);
-
-      if (unlinkError) {
-        console.error("Failed to unlink files from archived transactions:", unlinkError);
+    try {
+      // Soft-delete all archived transactions
+      const ids = txs.map((tx: { id: string }) => tx.id);
+      const batchSize = 50;
+      for (let i = 0; i < ids.length; i += batchSize) {
+        const batch = ids.slice(i, i + batchSize);
+        const { error: archiveError } = await supabase
+          .from("transactions")
+          .update({ deleted_at: new Date().toISOString() })
+          .in("id", batch);
+        
+        if (archiveError) throw archiveError;
       }
+
+      // Unlink all files associated with archived transactions
+      for (let i = 0; i < ids.length; i += batchSize) {
+        const batch = ids.slice(i, i + batchSize);
+        const { error: unlinkError } = await supabase
+          .from("project_files")
+          .update({ transaction_id: null })
+          .in("transaction_id", batch);
+
+        if (unlinkError) throw unlinkError;
+      }
+
+      // Export as CSV after successful DB updates
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `archive_${archiveFrom}_${archiveTo}.csv`;
+      a.click();
+      
+      // Invalidate file list cache to refresh UI with unlinked files
+      queryClient.invalidateQueries({ queryKey: ["project-files", activeProject.id] });
+      queryClient.invalidateQueries({ queryKey: ["transactions", activeProject.id] });
+
+      setArchiveFrom("");
+      setArchiveTo("");
+      toast.success(t("admin.archiveSuccess").replace("{n}", String(txs.length)));
+    } catch (err) {
+      console.error("Archive failed:", err);
+      toast.error(t("admin.archiveError") || "Failed to archive transactions");
+    } finally {
+      URL.revokeObjectURL(url);
+      setArchiving(false);
     }
-
-    // Invalidate file list cache to refresh UI with unlinked files
-    queryClient.invalidateQueries({ queryKey: ["project-files", activeProject.id] });
-
-    setArchiving(false);
-    setArchiveFrom("");
-    setArchiveTo("");
-    toast.success(t("admin.archiveSuccess").replace("{n}", String(txs.length)));
   };
 
   const handleDeleteProject = async () => {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -670,6 +670,8 @@ const Dashboard = () => {
                 headers={headers} 
                 customColumns={customColumns} 
                 isViewer={isViewer}
+                role={effectiveRole}
+                isOwner={isOwner}
                 hasNextPage={hasNextPage}
                 fetchNextPage={fetchNextPage}
                 isFetchingNextPage={isFetchingNextPage}
@@ -740,6 +742,8 @@ const Dashboard = () => {
               onDelete={deleteTransaction}
               customColumns={customColumns}
               isViewer={isViewer}
+              role={effectiveRole}
+              isOwner={isOwner}
               transactionList={bulkEditTxs.length > 0 ? bulkEditTxs : navigableTxs}
               onNavigate={handleNavigateTx}
               allTransactions={transactions}

--- a/src/types/files.ts
+++ b/src/types/files.ts
@@ -11,7 +11,7 @@ export type FileUploadResult = {
   path: string;
 };
 
-export const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB in bytes (Supabase limit)
+export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB in bytes (Supabase limit)
 export const IMAGE_COMPRESSION_THRESHOLD = 1 * 1024 * 1024; // 1 MB (Threshold to trigger image compression)
 export const SIGNED_URL_EXPIRY = 60 * 60; // 60 minutes in seconds
 

--- a/src/types/files.ts
+++ b/src/types/files.ts
@@ -58,6 +58,7 @@ export const EXTENSION_TO_MIME: Record<string, string> = {
  * @returns Lowercase file extension with dot (e.g., ".pdf")
  */
 export const getFileExtension = (filename: string): string => {
+  if (!filename || typeof filename !== 'string') return '';
   const ext = filename.toLowerCase().split('.').pop();
   return ext ? `.${ext}` : '';
 };

--- a/src/types/files.ts
+++ b/src/types/files.ts
@@ -59,8 +59,11 @@ export const EXTENSION_TO_MIME: Record<string, string> = {
  */
 export const getFileExtension = (filename: string): string => {
   if (!filename || typeof filename !== 'string') return '';
-  const ext = filename.toLowerCase().split('.').pop();
-  return ext ? `.${ext}` : '';
+  const lastIndex = filename.lastIndexOf('.');
+  if (lastIndex > 0 && lastIndex < filename.length - 1) {
+    return filename.substring(lastIndex).toLowerCase();
+  }
+  return '';
 };
 
 /**


### PR DESCRIPTION
This PR encompasses several improvements and bug fixes:

### 1. UI & Pagination
- **Pagination Fix**: Resolved text truncation in the 'entries per page' selector using rem units for better scaling.
- **Modal Centering**: Added max-width (2xl) and centered all transaction/file modals (Add, Detail, Bulk Edit, Upload) for better presentation on ultra-wide displays.
- **Image Preview**: Added zoom in/out/reset controls and enhanced scaling for image attachments.

### 2. Permissions & Logic
- **Owner/Admin Permissions**: Broadened permissions to allow owners and admins to select, edit, and delete any transaction.
- **File Upload Restoration**: Added safety checks and fixed upload modes to resolve TypeErrors during file attachment.

### 3. Internationalization (Korean)
- **Search Improvement**: Users can now search for '수입' (Income) or '지출' (Expense) in the transaction list.
- **Export Translation**: Ensured transaction types are correctly translated in CSV, Excel, and Markdown exports.
- **Toast Translations**: Translated all transaction-related notification toasts (e.g., 'Transaction added!').

### 4. File Handling
- **Increased Limits**: Upload size limit increased to 10MB.
- **Optimized Compression**: Image compression rate set to 50% (0.5 quality).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image zoom controls added to file preview (zoom in/out/reset).
  * Exports (CSV/XLS/Markdown) now use localized transaction type labels.

* **Improvements**
  * Bottom sheets centered and constrained for better layout on wide screens.
  * File upload limit increased to 10 MB.
  * File extension detection more robust; image compression quality reduced for smaller uploads.
  * Transaction list and detail views respect admin/owner privileges (edit/delete/select behavior).

* **Bug Fixes**
  * Import/export now normalize localized type labels for reliable CSV/XLS/Markdown handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->